### PR TITLE
Fix .rels XML relationship type of core-properties

### DIFF
--- a/src/Writer/XLSX/Helper/FileSystemHelper.php
+++ b/src/Writer/XLSX/Helper/FileSystemHelper.php
@@ -615,7 +615,7 @@ final class FileSystemHelper implements FileSystemWithRootFolderHelperInterface
     {
         $relationshipsXmlContents = <<<'EOD'
             <Relationship Id="rIdWorkbook" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
-            <Relationship Id="rIdCore" Type="http://schemas.openxmlformats.org/officedocument/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+            <Relationship Id="rIdCore" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
             <Relationship Id="rIdApp" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
             EOD;
 


### PR DESCRIPTION
Document properties are not visible when set, this fixes that

Fix .rels XML relationship type of core-properties, see: https://learn.microsoft.com/en-us/office/dev/add-ins/word/create-better-add-ins-for-word-with-office-open-xml#create-your-own-markup-best-practices

Before fix:
![before_fix](https://github.com/user-attachments/assets/24b7db01-fed0-434f-a903-74d32ff514be)

After fix:
![after_fix](https://github.com/user-attachments/assets/58338227-361e-4538-824a-e8962d5f820e)
